### PR TITLE
Hide long descriptions in feed

### DIFF
--- a/src/components/feed/item/index.tsx
+++ b/src/components/feed/item/index.tsx
@@ -1,7 +1,8 @@
 import cn from "classnames";
 import { Link } from "gatsby";
 import Image from "gatsby-image";
-import React from "react";
+import React, { useEffect, useRef } from "react";
+import { useRafState, useWindowSize } from "react-use";
 
 import { IFeedPostData } from "../../../pages/index";
 
@@ -18,6 +19,17 @@ interface IFeedItemPorps extends IFeedPostData {
 function FeedItem({ big, fields, frontmatter, timeToRead }: IFeedItemPorps) {
   const { title, description, date, picture, author } = frontmatter;
   const { avatar, name } = author.childMarkdownRemark.frontmatter;
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const { width } = useWindowSize();
+  const [isOverflown, setIsOverflown] = useRafState(true);
+
+  useEffect(() => {
+    if (bodyRef.current) {
+      const { scrollHeight, clientHeight } = bodyRef.current;
+
+      setIsOverflown(scrollHeight <= clientHeight);
+    }
+  }, [width]);
 
   return (
     <div
@@ -37,7 +49,10 @@ function FeedItem({ big, fields, frontmatter, timeToRead }: IFeedItemPorps) {
           <Placeholder className={styles.picture} />
         )}
       </Link>
-      <div className={styles.body}>
+      <div
+        className={cn(styles.body, !isOverflown && styles.overflown)}
+        ref={bodyRef}
+      >
         <Link to={fields.slug} className={styles.title}>
           {title}
         </Link>

--- a/src/components/feed/item/styles.module.css
+++ b/src/components/feed/item/styles.module.css
@@ -84,7 +84,23 @@
 }
 
 .body {
+  position: relative;
+  overflow: hidden;
   padding: 10px 30px;
+
+  &.overflown::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 30px;
+    background: linear-gradient(
+      0deg,
+      rgba(238, 244, 248, 1) 0%,
+      rgba(238, 244, 248, 0) 100%
+    );
+  }
 
   @media (--md-scr) {
     .big & {
@@ -99,7 +115,10 @@
   }
 
   @media (--lg-scr) {
+    max-height: 166px;
+
     .big & {
+      max-height: 314px;
       padding: 30px;
     }
   }
@@ -112,22 +131,16 @@
   @mixin hover;
 
   display: block;
-  overflow: hidden;
-  max-height: 60px;
   text-decoration: none;
   color: var(--color-black);
 
   @media (--sm-scr) {
     @mixin h3-mobile;
-
-    max-height: auto;
   }
 
   @media (--lg-scr) {
     .big & {
       @mixin h2-desktop;
-
-      max-height: 80px;
     }
   }
 
@@ -139,18 +152,11 @@
 .description {
   @mixin text-secondary;
 
-  overflow: hidden;
-  max-height: 96px;
   margin-top: 10px;
   color: var(--color-gray);
 
-  @media (--sm-scr) {
-    max-height: auto;
-  }
-
   @media (--lg-scr) {
     .big & {
-      max-height: 240px;
       margin-top: 40px;
     }
   }


### PR DESCRIPTION
Fix #12.

- Removed line limit for title and desrciption.
- Added line limit to their common wrapper.
- If wrapper content overflows wrapper height, container hides overflown content with gradient.