### PR TITLE
Update styles for horizontal splitter

### DIFF
--- a/src/components/markdown/styles.module.css
+++ b/src/components/markdown/styles.module.css
@@ -207,9 +207,15 @@
   }
 
   hr {
-    border: solid var(--color-light-gray);
-    border-width: 1px 0 0;
-    height: 0;
+    border: none;
+    text-align: center;
+    font-weight: 400;
+
+    &::before {
+      content: '...';
+      letter-spacing: 0.6em;
+      font-size: 28px;
+    }
   }
 
   abbr,


### PR DESCRIPTION
 fixes #14

Comparion after Updated:
<img width="1198" alt="update splitter design" src="https://user-images.githubusercontent.com/5623766/71657498-ebd67700-2d61-11ea-8f13-503d09cfa75e.png">
