### PR TITLE
fix post thumbnail cropping and improve sharpness

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -92,10 +92,20 @@ export const pageQuery = graphql`
             descriptionLong
             picture {
               childImageSharp {
-                big: fluid(maxWidth: 650, maxHeight: 450) {
+                big: fluid(
+                  maxWidth: 650
+                  maxHeight: 450
+                  cropFocus: CENTER
+                  quality: 90
+                ) {
                   ...GatsbyImageSharpFluid_withWebp
                 }
-                small: fluid(maxWidth: 300, maxHeight: 250) {
+                small: fluid(
+                  maxWidth: 300
+                  maxHeight: 250
+                  cropFocus: CENTER
+                  quality: 90
+                ) {
                   ...GatsbyImageSharpFluid_withWebp
                 }
               }


### PR DESCRIPTION
closes https://github.com/iterative/blog/issues/43


#### Cropping correction:
<img width="713" alt="Screenshot 2020-01-05 at 1 19 39 PM" src="https://user-images.githubusercontent.com/5623766/71777182-20466f00-2fbe-11ea-9df9-dd83ac86f320.png">


#### Sharpness Improvement:
![sharpness](https://user-images.githubusercontent.com/5623766/71777107-6818c680-2fbd-11ea-832d-f612422625d8.png)
 
