### PR TITLE
improve highlighting

### DIFF
--- a/config/prismjs/dvc-hook.js
+++ b/config/prismjs/dvc-hook.js
@@ -2,21 +2,13 @@ const Prism = require('prismjs');
 
 // Make sure the $ part of the command prompt in shell
 // examples isn't copiable by making it an 'input' token.
-const rInput = /^\$\s+$/m;
-const rLineSplit = /(?<=\n)/; // split lines without losing the \n
 Prism.hooks.add('after-tokenize', env => {
   if (env.language !== 'dvc') return;
 
-  env.tokens = env.tokens.flatMap(contents => {
-    if (typeof contents === 'string' && rInput.test(contents)) {
-      // one or more lines contain a prompt (`$ `)
-      return contents.split(rLineSplit).map(line => {
-        if (rInput.test(line)) {
-          return new Prism.Token('input', line, null, line, false);
-        }
-        return line;
-      });
+  for (const token of env.tokens) {
+    if (token.type === 'line' && /^\$\s+$/.test(token.content[0])) {
+      const old = token.content[0];
+      token.content[0] = new Prism.Token('input', old, null, old, false);
     }
-    return [contents];
-  });
+  }
 });

--- a/config/prismjs/dvc-hook.js
+++ b/config/prismjs/dvc-hook.js
@@ -1,0 +1,15 @@
+const Prism = require('prismjs');
+
+// Make sure the $ part of the command prompt in shell
+// examples isn't copiable by making it an 'input' token.
+Prism.hooks.add('after-tokenize', env => {
+  if (env.language !== 'dvc') return;
+
+  const { tokens } = env;
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i].type === 'line' && /\$\s?/.test(tokens[i].content[0])) {
+      const old = tokens[i].content[0];
+      tokens[i].content[0] = new Prism.Token('input', '$ ', null, '$ ', false);
+    }
+  }
+});

--- a/config/prismjs/dvc-hook.js
+++ b/config/prismjs/dvc-hook.js
@@ -2,14 +2,21 @@ const Prism = require('prismjs');
 
 // Make sure the $ part of the command prompt in shell
 // examples isn't copiable by making it an 'input' token.
+const rInput = /^\$\s+$/m;
+const rLineSplit = /(?<=\n)/; // split lines without losing the \n
 Prism.hooks.add('after-tokenize', env => {
   if (env.language !== 'dvc') return;
 
-  const { tokens } = env;
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i].type === 'line' && /^\$\s?$/.test(tokens[i].content[0])) {
-      const old = tokens[i].content[0];
-      tokens[i].content[0] = new Prism.Token('input', '$ ', null, '$ ', false);
+  env.tokens = env.tokens.flatMap(contents => {
+    if (typeof contents === 'string' && rInput.test(contents)) {
+      // one or more lines contain a prompt (`$ `)
+      return contents.split(rLineSplit).map(line => {
+        if (rInput.test(line)) {
+          return new Prism.Token('input', line, null, line, false);
+        }
+        return line;
+      });
     }
-  }
+    return [contents];
+  });
 });

--- a/config/prismjs/dvc-hook.js
+++ b/config/prismjs/dvc-hook.js
@@ -7,7 +7,7 @@ Prism.hooks.add('after-tokenize', env => {
 
   const { tokens } = env;
   for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i].type === 'line' && /\$\s?/.test(tokens[i].content[0])) {
+    if (tokens[i].type === 'line' && /^\$\s?$/.test(tokens[i].content[0])) {
       const old = tokens[i].content[0];
       tokens[i].content[0] = new Prism.Token('input', '$ ', null, '$ ', false);
     }

--- a/config/prismjs/dvc.js
+++ b/config/prismjs/dvc.js
@@ -1,3 +1,11 @@
+// we require prism and load its bash module so we have
+// Prism.languages.bash to embed into our DVC language.
+
+const Prism = require('prismjs');
+require('prismjs/components/prism-bash');
+require('./dvc-hook');
+const { bash } = Prism.languages;
+
 // Command arrays are intentionally reverse sorted
 // to prevent shorter matches before longer ones
 
@@ -71,24 +79,31 @@ const dvc = [
 
 const beforeCommand = String.raw`(\$[\s(]+|;\s*)`;
 
-module.exports = {
-  dvc: {
-    pattern: new RegExp(
-      String.raw`${beforeCommand}\b(?:dvc (?:${dvc.join('|')}))\b`
-    ),
-    greedy: true,
-    lookbehind: true
+Prism.languages.dvc = {
+  line: {
+    pattern: /(?<=(^|\n))\$[\s\S]*?[^\\](:?\n|$)/,
+    inside: {
+      dvc: {
+        pattern: new RegExp(
+          String.raw`${beforeCommand}\b(?:dvc (?:${dvc.join('|')}))\b`
+        ),
+        greedy: true,
+        lookbehind: true
+      },
+      git: {
+        pattern: new RegExp(
+          String.raw`${beforeCommand}\b(?:git (?:${git.join('|')}))\b`
+        ),
+        greedy: true,
+        lookbehind: true
+      },
+      command: {
+        pattern: new RegExp(String.raw`${beforeCommand}\b[a-zA-Z0-9\-_]+\b`),
+        greedy: true,
+        lookbehind: true
+      },
+      ...bash
+    }
   },
-  git: {
-    pattern: new RegExp(
-      String.raw`${beforeCommand}\b(?:git (?:${git.join('|')}))\b`
-    ),
-    greedy: true,
-    lookbehind: true
-  },
-  command: {
-    pattern: new RegExp(String.raw`${beforeCommand}\b[a-zA-Z0-9\-_]+\b`),
-    greedy: true,
-    lookbehind: true
-  }
+  comment: bash.comment
 };

--- a/config/prismjs/dvc.js
+++ b/config/prismjs/dvc.js
@@ -71,17 +71,7 @@ const dvc = [
 
 const beforeCommand = String.raw`(\$[\s(]+|;\s*)`;
 
-const variable = {
-  pattern: /\$[a-zA-Z_][a-zA-Z_0-9]*/,
-  greedy: true
-};
-
-const comment = {
-  pattern: /#.*/,
-  greedy: true
-};
-
-const insideLine = {
+module.exports = {
   dvc: {
     pattern: new RegExp(
       String.raw`${beforeCommand}\b(?:dvc (?:${dvc.join('|')}))\b`
@@ -97,33 +87,8 @@ const insideLine = {
     lookbehind: true
   },
   command: {
-    pattern: new RegExp(String.raw`${beforeCommand}\b[a-zA-Z0-9]+\b`),
+    pattern: new RegExp(String.raw`${beforeCommand}\b[a-zA-Z0-9\-_]+\b`),
     greedy: true,
     lookbehind: true
-  },
-  string: {
-    pattern: /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
-    greedy: true,
-    inside: {
-      variable: { ...variable }
-    }
-  },
-  variable
-};
-
-const subcommand = {
-  pattern: /\$\((.+)\)/,
-  inside: { ...insideLine },
-  alias: 'important'
-};
-
-module.exports = {
-  comment: { ...comment },
-  line: {
-    pattern: /(?<=(^|\n))\$[\s\S]*?[^\\](:?\n|$)/,
-    inside: {
-      subcommand,
-      ...insideLine
-    }
   }
 };

--- a/config/prismjs/dvc.js
+++ b/config/prismjs/dvc.js
@@ -92,18 +92,82 @@ const dvc = [
   'add'
 ];
 
+const keywords = [
+  'while',
+  'until',
+  'time',
+  'then',
+  'select',
+  'in',
+  'if',
+  'function',
+  'for',
+  'fi',
+  'esac',
+  'else',
+  'elif',
+  'done',
+  'do',
+  'case'
+];
+
+const beforeCommand = String.raw`(\$[\s(]+|;\s*)`;
+
+const variable = {
+  pattern: /\$[a-zA-Z_][a-zA-Z_0-9]*/,
+  greedy: true
+};
+
+const comment = {
+  pattern: /#.*/,
+  greedy: true
+};
+
+const insideLine = {
+  command: {
+    pattern: new RegExp(
+      String.raw`${beforeCommand}\b(?:${commands.concat(keywords).join('|')})\b`
+    ),
+    greedy: true,
+    lookbehind: true
+  },
+  git: {
+    pattern: new RegExp(
+      String.raw`${beforeCommand}\b(?:git (?:${git.join('|')}))\b`
+    ),
+    greedy: true,
+    lookbehind: true
+  },
+  dvc: {
+    pattern: new RegExp(
+      String.raw`${beforeCommand}\b(?:dvc (?:${dvc.join('|')}))\b`
+    ),
+    greedy: true,
+    lookbehind: true
+  },
+  string: {
+    pattern: /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+    greedy: true,
+    inside: {
+      variable: { ...variable }
+    }
+  },
+  variable
+};
+
+const subcommand = {
+  pattern: /\$\((.+)\)/,
+  inside: { ...insideLine },
+  alias: 'important'
+};
+
 module.exports = {
+  comment: { ...comment },
   line: {
     pattern: /(?<=(^|\n))\$[\s\S]*?[^\\](:?\n|$)/,
     inside: {
-      input: /^\$\s+/,
-      string: {
-        pattern: /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
-        greedy: true
-      },
-      command: new RegExp(`\\b(?:${commands.join('|')})\\b`),
-      git: new RegExp(`git \\b(?:${git.join('|')})\\b`),
-      dvc: new RegExp(`dvc \\b(?:${dvc.join('|')})\\b`)
+      subcommand,
+      ...insideLine
     }
   }
 };

--- a/config/prismjs/dvc.js
+++ b/config/prismjs/dvc.js
@@ -1,37 +1,14 @@
 // Command arrays are intentionally reverse sorted
 // to prevent shorter matches before longer ones
 
-const commands = [
-  'which',
-  'wget',
-  'virtualenv',
-  'vi',
-  'unzip',
-  'tree',
-  'tar',
-  'sudo',
-  'source',
-  'rm',
-  'python',
-  'pip',
-  'mkdir',
-  'md5',
-  'ls',
-  'file',
-  'export',
-  'exec',
-  'echo',
-  'du',
-  'curl',
-  'cp',
-  'cd',
-  'cat',
-  'autoload'
-];
-
 const git = [
   'tag',
   'status',
+  'remote update',
+  'remote rename',
+  'remote remove',
+  'remote add',
+  'remote',
   'push',
   'pull',
   'merge',
@@ -92,25 +69,6 @@ const dvc = [
   'add'
 ];
 
-const keywords = [
-  'while',
-  'until',
-  'time',
-  'then',
-  'select',
-  'in',
-  'if',
-  'function',
-  'for',
-  'fi',
-  'esac',
-  'else',
-  'elif',
-  'done',
-  'do',
-  'case'
-];
-
 const beforeCommand = String.raw`(\$[\s(]+|;\s*)`;
 
 const variable = {
@@ -124,9 +82,9 @@ const comment = {
 };
 
 const insideLine = {
-  command: {
+  dvc: {
     pattern: new RegExp(
-      String.raw`${beforeCommand}\b(?:${commands.concat(keywords).join('|')})\b`
+      String.raw`${beforeCommand}\b(?:dvc (?:${dvc.join('|')}))\b`
     ),
     greedy: true,
     lookbehind: true
@@ -138,10 +96,8 @@ const insideLine = {
     greedy: true,
     lookbehind: true
   },
-  dvc: {
-    pattern: new RegExp(
-      String.raw`${beforeCommand}\b(?:dvc (?:${dvc.join('|')}))\b`
-    ),
+  command: {
+    pattern: new RegExp(String.raw`${beforeCommand}\b[a-zA-Z0-9]+\b`),
     greedy: true,
     lookbehind: true
   },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,5 @@
 const path = require('path');
-const dvc = require('./config/prismjs/dvc');
-require('./config/prismjs/dvc-hook');
+require('./config/prismjs/dvc');
 
 const title = 'Data Version Control · DVC';
 const keywords =
@@ -63,19 +62,7 @@ const plugins = [
         },
         'gatsby-remark-responsive-iframe',
         {
-          resolve: 'gatsby-remark-prismjs',
-          options: {
-            languageExtensions: [
-              {
-                language: 'dvc',
-                extend: 'bash',
-                // insert our definitions at the very start
-                insertBefore: {
-                  shebang: dvc
-                }
-              }
-            ]
-          }
+          resolve: 'gatsby-remark-prismjs'
         },
         'gatsby-remark-copy-linked-files',
         'gatsby-remark-smartypants'

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -68,7 +68,11 @@ const plugins = [
             languageExtensions: [
               {
                 language: 'dvc',
-                definition: dvc
+                extend: 'bash',
+                // insert our definitions at the very start
+                insertBefore: {
+                  shebang: dvc
+                }
               }
             ]
           }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,7 @@ const Prism = require('prismjs');
 // examples isn't copiable by making it an 'input' token.
 Prism.hooks.add('after-tokenize', env => {
   if (env.language !== 'dvc') return;
-  debugger;
+
   const { tokens } = env;
   for (let i = 0; i < tokens.length; i++) {
     if (tokens[i].type === 'line' && /\$\s?/.test(tokens[i].content[0])) {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,20 +1,6 @@
 const path = require('path');
 const dvc = require('./config/prismjs/dvc');
-const Prism = require('prismjs');
-
-// Make sure the $ part of the command prompt in shell
-// examples isn't copiable by making it an 'input' token.
-Prism.hooks.add('after-tokenize', env => {
-  if (env.language !== 'dvc') return;
-
-  const { tokens } = env;
-  for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i].type === 'line' && /\$\s?/.test(tokens[i].content[0])) {
-      const old = tokens[i].content[0];
-      tokens[i].content[0] = new Prism.Token('input', '$ ', null, '$ ', false);
-    }
-  }
-});
+require('./config/prismjs/dvc-hook');
 
 const title = 'Data Version Control · DVC';
 const keywords =

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,20 @@
 const path = require('path');
 const dvc = require('./config/prismjs/dvc');
+const Prism = require('prismjs');
+
+// Make sure the $ part of the command prompt in shell
+// examples isn't copiable by making it an 'input' token.
+Prism.hooks.add('after-tokenize', env => {
+  if (env.language !== 'dvc') return;
+  debugger;
+  const { tokens } = env;
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i].type === 'line' && /\$\s?/.test(tokens[i].content[0])) {
+      const old = tokens[i].content[0];
+      tokens[i].content[0] = new Prism.Token('input', '$ ', null, '$ ', false);
+    }
+  }
+});
 
 const title = 'Data Version Control · DVC';
 const keywords =

--- a/src/components/markdown/styles.module.css
+++ b/src/components/markdown/styles.module.css
@@ -375,7 +375,10 @@
         color: #0086b3;
       }
 
-      .token.dvc,
+      .token.dvc {
+        color: #73bdd5;
+      }
+
       .token.command,
       .token.selector,
       .token.atrule,

--- a/src/components/markdown/styles.module.css
+++ b/src/components/markdown/styles.module.css
@@ -371,12 +371,12 @@
         color: #0086b3;
       }
 
-      .token.git {
+      .token.dvc {
         color: #0086b3;
       }
 
-      .token.dvc {
-        color: #73bdd5;
+      .token.git {
+        color: #d57a66;
       }
 
       .token.command,

--- a/src/components/markdown/styles.module.css
+++ b/src/components/markdown/styles.module.css
@@ -308,6 +308,11 @@
       color: #a0a0a0;
     }
 
+    /* DVC's command outputs are a different color */
+    code[class*="language-dvc"] {
+      color: #ccc;
+    }
+
     :global {
       .gatsby-highlight-code-line {
         display: block;
@@ -319,7 +324,6 @@
 
       .language-dvc {
         font-weight: normal;
-        color: #ccc !important;
 
         .token.line {
           font-weight: bold;

--- a/src/components/markdown/styles.module.css
+++ b/src/components/markdown/styles.module.css
@@ -317,8 +317,12 @@
         background: #55436a;
       }
 
-      .token.line {
+      .language-dvc {
         font-weight: bold;
+
+        .token.comment {
+          font-weight: normal;
+        }
       }
 
       .token.input {

--- a/src/components/markdown/styles.module.css
+++ b/src/components/markdown/styles.module.css
@@ -372,11 +372,11 @@
       }
 
       .token.dvc {
-        color: #0086b3;
+        color: #56b1d0;
       }
 
       .token.git {
-        color: #d57a66;
+        color: #e9836e;
       }
 
       .token.command,

--- a/src/components/markdown/styles.module.css
+++ b/src/components/markdown/styles.module.css
@@ -318,10 +318,17 @@
       }
 
       .language-dvc {
-        font-weight: bold;
+        font-weight: normal;
+        color: #ccc !important;
+
+        .token.line {
+          font-weight: bold;
+          color: #a0a0a0;
+        }
 
         .token.comment {
           font-weight: normal;
+          color: #a0a0a0;
         }
       }
 


### PR DESCRIPTION
I've added a bunch of syntax to the prism language. To keep the user from selecting the `$ ` part of commands I added a prism hook, which acts after tokenisation and changes the token stream.

The for loop support isn't stellar, but since I don't see us using too many for loops I didn't spend too much time on this. However it's possible to improve the support if we are OK with not highlighting the "do" keyword, which I think is quite a bit of a loss.

Fixes #82 

## Before

![Screenshot from 2020-01-27 19-18-59](https://user-images.githubusercontent.com/1611595/73206140-4c2abf80-413a-11ea-9f5d-8838315df383.png)

## After

![Screenshot from 2020-01-27 19-18-05](https://user-images.githubusercontent.com/1611595/73206180-5fd62600-413a-11ea-9c0e-8ccffe508700.png)
