### PR TITLE
fix: #61 card text issues

### DIFF
--- a/src/components/feed/item/styles.module.css
+++ b/src/components/feed/item/styles.module.css
@@ -87,6 +87,7 @@
   position: relative;
   overflow: hidden;
   padding: 10px 30px;
+  max-height: 166px;
 
   &.overflown::after {
     content: "";
@@ -115,8 +116,6 @@
   }
 
   @media (--lg-scr) {
-    max-height: 166px;
-
     .big & {
       max-height: 314px;
       padding: 30px;


### PR DESCRIPTION
Issue No 1. is easily fixed due to a small oversight of overflow hidden and max-height needed together.
Issue No 2 however, the entire metadata needs a restructure, involving more than a few adjustments.
It's not a bug, its the natural behavior, the text is too long.

 in my opinion, a do-over is needed for the entire card.