### PR TITLE
Fix: card text issues #61 Part 2

### DIFF
--- a/src/components/feed/item/styles.module.css
+++ b/src/components/feed/item/styles.module.css
@@ -86,7 +86,7 @@
 .body {
   position: relative;
   overflow: hidden;
-  padding: 10px 30px;
+  padding: 10px 20px;
   max-height: 166px;
 
   &.overflown::after {
@@ -163,9 +163,9 @@
 
 .meta {
   position: absolute;
-  right: 30px;
+  right: 20px;
   bottom: 15px;
-  left: 30px;
+  left: 20px;
 
   @media (--md-scr) {
     .big & {

--- a/src/components/meta/index.tsx
+++ b/src/components/meta/index.tsx
@@ -32,7 +32,7 @@ function FeedMeta({
       <ul className={styles.list}>
         <li className={styles.item}>{name}</li>
         <li className={styles.item}>
-          {date} • {timeToRead} min. read
+          {date} • {timeToRead} min read
         </li>
         {commentsUrl && typeof commentsCount === 'number' && (
           <li className={styles.item}>

--- a/src/components/meta/styles.module.css
+++ b/src/components/meta/styles.module.css
@@ -4,15 +4,15 @@
   flex-wrap: wrap;
   align-items: center;
   min-height: 44px;
-  padding-left: 30px;
+  padding-left: 40px;
 }
 
 .avatar {
   position: absolute !important;
   top: 50%;
   left: 0;
-  margin-top: -15px;
-  border-radius: 15px;
+  margin-top: -20px;
+  border-radius: 20px;
 }
 
 .list {
@@ -28,7 +28,7 @@
   display: inline-block;
   margin-right: 14px;
   white-space: nowrap;
-  line-height: 22px;
+  line-height: 20px;
   color: var(--color-gray);
 
   &::before {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -116,7 +116,7 @@ export const pageQuery = graphql`
                   name
                   avatar {
                     childImageSharp {
-                      fixed(width: 30, height: 30) {
+                      fixed(width: 40, height: 40) {
                         ...GatsbyImageSharpFixed_withWebp
                       }
                     }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -86,7 +86,7 @@ export const pageQuery = graphql`
             slug
           }
           frontmatter {
-            date(formatString: "MMMM DD, YYYY")
+            date(formatString: "MMM DD, YYYY")
             title
             description
             descriptionLong

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -97,7 +97,7 @@ export const pageQuery = graphql`
               name
               avatar {
                 childImageSharp {
-                  fixed(width: 30, height: 30) {
+                  fixed(width: 40, height: 40) {
                     ...GatsbyImageSharpFixed_withWebp
                   }
                 }


### PR DESCRIPTION
Issue #61 Part 2
Card inner padding decreased from 30px to 20px.
Avatar size from 30px to 40px to match 2 lines at 20px line-height each.
Date format is changed to reduce the number of characters on the 2nd line.
Post meta area padding is adjusted as well to fit the new spacing

Avatar changes are reflected in the single post page as well, without messy side effects.
