### PR TITLE
tags: create tag lists to list posts of a certain tag

### DIFF
--- a/src/components/feed/index.tsx
+++ b/src/components/feed/index.tsx
@@ -1,4 +1,8 @@
+import { graphql } from 'gatsby';
+
 import React from 'react';
+
+import cn from 'classnames';
 
 import { IFeedPostData } from '../../pages/index';
 
@@ -7,31 +11,49 @@ import FeedItem from './item';
 import styles from './styles.module.css';
 
 interface IFeedProps {
-  posts: [
-    {
-      node: IFeedPostData;
-    }
-  ];
+  feedPostList: Array<{
+    node: IFeedPostData;
+  }>;
+  bigFirst?: boolean;
+  header: React.ReactNode;
+  leadParagraph?: React.ReactNode;
 }
 
-function Feed({ posts }: IFeedProps) {
+function Feed({
+  feedPostList,
+  bigFirst = true,
+  header,
+  leadParagraph
+}: IFeedProps) {
   return (
     <div className={styles.wrapper}>
-      <div className={styles.meta}>
-        <div className={styles.header}>Data Version Control in Real Life</div>
-        <div className={styles.lead}>
-          We write about machine learning workflow. From data versioning and
-          processing to model productionization. We share our news, findings,
-          interesting reads, community takeaways.
-        </div>
+      <div
+        className={cn(styles.meta, {
+          [styles.metaSlim]: bigFirst
+        })}
+      >
+        <h2 className={styles.header}>{header}</h2>
+        {leadParagraph && <div className={styles.lead}>{leadParagraph}</div>}
       </div>
       <div className={styles.posts}>
-        {posts.map(({ node }, index) => (
-          <FeedItem {...node} key={node.id} big={index === 0} />
+        {feedPostList.map(({ node }, index) => (
+          <FeedItem
+            feedPost={node}
+            key={node.id}
+            big={bigFirst && index === 0}
+          />
         ))}
       </div>
     </div>
   );
 }
+
+export const query = graphql`
+  fragment FeedPostList on MarkdownRemarkEdge {
+    node {
+      ...FeedPost
+    }
+  }
+`;
 
 export default Feed;

--- a/src/components/feed/item/index.tsx
+++ b/src/components/feed/item/index.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import { Link } from 'gatsby';
+import { graphql, Link } from 'gatsby';
 import Image from 'gatsby-image';
 import React, { useEffect, useRef } from 'react';
 import { useRafState, useWindowSize } from 'react-use';
@@ -12,11 +12,15 @@ import styles from './styles.module.css';
 
 import { ReactComponent as Placeholder } from './placeholder.svg';
 
-interface IFeedItemPorps extends IFeedPostData {
+interface IFeedItemProps {
   big?: boolean;
+  feedPost: IFeedPostData;
 }
 
-function FeedItem({ big, fields, frontmatter, timeToRead }: IFeedItemPorps) {
+function FeedItem({
+  big,
+  feedPost: { fields, frontmatter, timeToRead }
+}: IFeedItemProps) {
   const { title, description, date, picture, author } = frontmatter;
   const { avatar, name } = author.childMarkdownRemark.frontmatter;
   const bodyRef = useRef<HTMLDivElement>(null);
@@ -67,5 +71,55 @@ function FeedItem({ big, fields, frontmatter, timeToRead }: IFeedItemPorps) {
     </div>
   );
 }
+
+export const query = graphql`
+  fragment FeedPost on MarkdownRemark {
+    id
+    timeToRead
+    fields {
+      slug
+    }
+    frontmatter {
+      date(formatString: "MMM DD, YYYY")
+      title
+      description
+      descriptionLong
+      picture {
+        childImageSharp {
+          big: fluid(
+            maxWidth: 650
+            maxHeight: 450
+            cropFocus: CENTER
+            quality: 90
+          ) {
+            ...GatsbyImageSharpFluid_withWebp
+          }
+          small: fluid(
+            maxWidth: 300
+            maxHeight: 250
+            cropFocus: CENTER
+            quality: 90
+          ) {
+            ...GatsbyImageSharpFluid_withWebp
+          }
+        }
+      }
+      author {
+        childMarkdownRemark {
+          frontmatter {
+            name
+            avatar {
+              childImageSharp {
+                fixed(width: 40, height: 40, quality: 50, cropFocus: CENTER) {
+                  ...GatsbyImageSharpFixed_withWebp
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
 
 export default FeedItem;

--- a/src/components/feed/styles.module.css
+++ b/src/components/feed/styles.module.css
@@ -13,13 +13,16 @@
 }
 
 .meta {
-  max-width: 650px;
   margin: 20px 0 40px;
 
   @media (--sm-scr) {
     max-width: auto;
     margin: 30px;
   }
+}
+
+.metaSlim {
+  max-width: 650px;
 }
 
 .header {
@@ -30,6 +33,8 @@
   @media (--lg-scr) {
     @mixin h1-desktop;
   }
+
+  margin: 0;
 }
 
 .lead {

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -7,6 +7,7 @@ import { IBlogPostData } from '../../templates/blog-post';
 
 import { getCommentsCount } from '../../api';
 import { pluralizeComments } from '../../utils/i18n';
+import tagToSlug from '../../utils/tag-to-slug';
 
 import Hero from '../hero';
 import Markdown from '../markdown';
@@ -95,9 +96,13 @@ function Post({ html, timeToRead, frontmatter, fields }: IBlogPostData) {
       {tags && (
         <div className={styles.tags}>
           {tags.map(tag => (
-            <div className={styles.tag} key={tag}>
+            <a
+              href={`/tags/${tagToSlug(tag)}`}
+              className={styles.tag}
+              key={tag}
+            >
               {tag}
-            </div>
+            </a>
           ))}
         </div>
       )}

--- a/src/components/post/styles.module.css
+++ b/src/components/post/styles.module.css
@@ -131,14 +131,20 @@
 .tag {
   @mixin text-secondary;
 
-  pointer-events: none;
   display: inline-block;
+  text-decoration: none;
   margin: 0 10px 10px 0;
   padding: 1px 9px;
   border: 1px solid var(--color-gray);
   border-radius: 4px;
   font-weight: 700;
   color: var(--color-gray);
+
+  &:hover,
+  &:focus {
+    color: var(--color-gray-hover);
+    border: 1px solid var(--color-gray-hover);
+  }
 }
 
 .comments {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,17 @@ function BlogIndex({ data }: IBlogIndexProps) {
   return (
     <Layout>
       <SEO title="Blog" defaultMetaTitle={true} />
-      <Feed posts={data.posts.edges} />
+      <Feed
+        feedPostList={data.posts.edges}
+        header="Data Version Control in Real Life"
+        leadParagraph={
+          <>
+            We write about machine learning workflow. From data versioning and
+            processing to model productionization. We share our news, findings,
+            interesting reads, community takeaways.
+          </>
+        }
+      />
     </Layout>
   );
 }
@@ -79,58 +89,7 @@ export const pageQuery = graphql`
       filter: { fileAbsolutePath: { regex: "/content/blog/" } }
     ) {
       edges {
-        node {
-          id
-          timeToRead
-          fields {
-            slug
-          }
-          frontmatter {
-            date(formatString: "MMM DD, YYYY")
-            title
-            description
-            descriptionLong
-            picture {
-              childImageSharp {
-                big: fluid(
-                  maxWidth: 650
-                  maxHeight: 450
-                  cropFocus: CENTER
-                  quality: 90
-                ) {
-                  ...GatsbyImageSharpFluid_withWebp
-                }
-                small: fluid(
-                  maxWidth: 300
-                  maxHeight: 250
-                  cropFocus: CENTER
-                  quality: 90
-                ) {
-                  ...GatsbyImageSharpFluid_withWebp
-                }
-              }
-            }
-            author {
-              childMarkdownRemark {
-                frontmatter {
-                  name
-                  avatar {
-                    childImageSharp {
-                      fixed(
-                        width: 40
-                        height: 40
-                        quality: 50
-                        cropFocus: CENTER
-                      ) {
-                        ...GatsbyImageSharpFixed_withWebp
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+        ...FeedPostList
       }
     }
   }

--- a/src/templates/tag-page.tsx
+++ b/src/templates/tag-page.tsx
@@ -1,0 +1,53 @@
+// Components
+import { graphql } from 'gatsby';
+import React from 'react';
+
+import Feed from '../components/feed';
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+import { IFeedPostData } from '../pages/index';
+
+interface IListQueryResult<ResultItem> {
+  totalCount: number;
+  edges: Array<{ node: ResultItem }>;
+}
+
+interface ITagPageTemplateProps {
+  pageContext: {
+    tag: string;
+  };
+  data: {
+    posts: IListQueryResult<IFeedPostData>;
+  };
+}
+
+const Tags = ({
+  pageContext: { tag },
+  data: { posts }
+}: ITagPageTemplateProps) => {
+  const title = `Posts tagged with "${tag}"`;
+
+  return (
+    <Layout>
+      <SEO title={title} defaultMetaTitle={true} />
+      <Feed feedPostList={posts.edges} bigFirst={false} header={title} />
+    </Layout>
+  );
+};
+
+export default Tags;
+
+export const pageQuery = graphql`
+  query($tag: String) {
+    posts: allMarkdownRemark(
+      limit: 2000
+      sort: { fields: [frontmatter___date], order: DESC }
+      filter: { frontmatter: { tags: { in: [$tag] } } }
+    ) {
+      totalCount
+      edges {
+        ...FeedPostList
+      }
+    }
+  }
+`;

--- a/src/utils/tag-to-slug.js
+++ b/src/utils/tag-to-slug.js
@@ -1,0 +1,6 @@
+module.exports = tag =>
+  tag
+    .trim()
+    .toLowerCase()
+    .replace(/\s/g, '-')
+    .replace(/-+/g, '-');


### PR DESCRIPTION
I've had to use GraphQL fragments to reuse queries. I've used fragments before and they were very effective when reusing components which need data. Gatsby's integration seems top notch. My reasoning for this was that the home page and the tag page use the same Feed component, and need to provide data to it without duplicating the complex Feed query.

I also think we could use centralisation in our types. Structures like `{ edges: Array<{ node: SomeType }> }` needn't be repeated.

Let me know if you'd like pagination in the tag pages. I don't think we'll need it for a long time.

Fixes #46 