### PR TITLE
enable circleCI in master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,4 @@ workflows:
 
   commit:
     jobs:
-      - test:
-          filters:
-            branches: { ignore: master }
+      - test


### PR DESCRIPTION
For some reason I disabled circleCI in master. Maybe because I thought it was enough to test incoming PRs. But sometimes surprises happen in complex merges.