### PR TITLE
subscribe: send event when user subscribes

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@reach/portal": "^0.5.0",
     "@reach/tooltip": "^0.5.4",
+    "@types/google.analytics": "^0.0.40",
     "classnames": "^2.2.6",
     "gatsby": "^2.19.1",
     "gatsby-image": "^2.2.39",

--- a/src/components/subscribe/form/index.tsx
+++ b/src/components/subscribe/form/index.tsx
@@ -1,6 +1,28 @@
-import React from 'react';
+import React, { FormEvent } from 'react';
 
 import styles from './styles.module.css';
+
+const honeyPot = 'b_a08bf93caae4063c4e6a351f6_24c0ecc49a';
+
+interface IFormElements {
+  [honeyPot]: HTMLFormElement;
+}
+
+const sendGAEvent = ({ target: form }: FormEvent<HTMLFormElement>) => {
+  const formElements: IFormElements = (form as any).elements;
+  if (formElements[honeyPot].value) {
+    // It's a bot.
+    return;
+  }
+
+  if (typeof window.ga === 'function') {
+    window.ga('send', 'event', {
+      eventCategory: 'blog-home',
+      eventAction: 'subscribe',
+      transport: 'beacon'
+    });
+  }
+};
 
 export default function SubscribeForm() {
   return (
@@ -11,6 +33,7 @@ export default function SubscribeForm() {
       id="mc-embedded-subscribe-form"
       name="mc-embedded-subscribe-form"
       target="_blank"
+      onSubmit={sendGAEvent}
     >
       <input
         className={styles.input}
@@ -23,11 +46,7 @@ export default function SubscribeForm() {
 
       {/*real people should not fill this in and expect good things - do not remove this or risk form bot signups*/}
       <div style={{ position: 'absolute', left: '-5000px' }} aria-hidden="true">
-        <input
-          type="text"
-          name="b_a08bf93caae4063c4e6a351f6_24c0ecc49a"
-          tabIndex={-1}
-        />
+        <input type="text" name={honeyPot} tabIndex={-1} />
       </div>
 
       <button

--- a/yarn.lock
+++ b/yarn.lock
@@ -1738,6 +1738,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/google.analytics@^0.0.40":
+  version "0.0.40"
+  resolved "https://registry.yarnpkg.com/@types/google.analytics/-/google.analytics-0.0.40.tgz#35526e9d78333423c430ade1c821ce54d0f0f850"
+  integrity sha512-R3HpnLkqmKxhUAf8kIVvDVGJqPtaaZlW4yowNwjOZUTmYUQEgHh8Nh5wkSXKMroNAuQM8gbXJHmNbbgA8tdb7Q==
+
 "@types/history@*":
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.4.tgz#06cbceb0ace6a342a9aafcb655a688cf38f6150d"


### PR DESCRIPTION
This sends a google analytics event when the user subscribes. It's probably easier to test in production.

Closes #38 (which also needs some mailchimp access)