### PR TITLE
markup: remove extra html and body tags

### DIFF
--- a/plugins/utils/convertHast.js
+++ b/plugins/utils/convertHast.js
@@ -5,7 +5,7 @@ const stringify = require('rehype-stringify');
 /** HAST - Hypertext Abstract Syntax Tree */
 function convertHtmlToHast(htmlString) {
   return unified()
-    .use(parse)
+    .use(parse, { fragment: true })
     .parse(htmlString);
 }
 


### PR DESCRIPTION
Markup in AST form, transformed by our plugins, was including a surrounding HTML and body tag. I traced this back to the function that converted HTML to hast in our plugins.

![Screenshot from 2020-02-19 20-30-28](https://user-images.githubusercontent.com/1611595/74873244-c2e06480-5356-11ea-988b-e161671c9ee8.png)