### PR TITLE
escape HTML special characters and tags within external link attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@reach/tooltip": "^0.5.4",
     "@types/google.analytics": "^0.0.40",
     "classnames": "^2.2.6",
+    "escape-html": "^1.0.3",
     "gatsby": "^2.19.19",
     "gatsby-image": "^2.2.39",
     "gatsby-plugin-twitter": "^2.1.18",

--- a/plugins/external-link-plugin/index.js
+++ b/plugins/external-link-plugin/index.js
@@ -1,5 +1,6 @@
 const visit = require('unist-util-visit');
 const { selectAll } = require('hast-util-select');
+const escape = require('escape-html');
 
 const {
   convertHastToHtml,
@@ -17,16 +18,16 @@ function isCorrectExternalLinkAttr(attrsKeyTagArray) {
 function renderTag(attrs) {
   return `
     <section class="elp-content-holder">
-      <a href=${attrs.href} class="external-link-preview">
+      <a href="${escape(attrs.href)}" class="external-link-preview">
           <div class="elp-description-holder">
-            <h4 class="elp-title">${attrs.title}</h4>
-            <div class="elp-description">${attrs.description}</div>
-            <div class="elp-link">${attrs.link}</div>
+            <h4 class="elp-title">${escape(attrs.title)}</h4>
+            <div class="elp-description">${escape(attrs.description)}</div>
+            <div class="elp-link">${escape(attrs.link)}</div>
           </div>
            ${
              attrs.image
                ? `<div class="elp-image-holder">
-                <img src="${attrs.image}" alt="${attrs.title}"/>
+                <img src="${escape(attrs.image)}" alt="${escape(attrs.title)}"/>
             </div>`
                : ``
            }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5218,7 +5218,7 @@ es6-weak-map@^2.0.2:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=


### PR DESCRIPTION
I was trying to remove the `<p><section>` sequence in this plugin, since it's invalid and forces the browser to change the HTML.

It was taking too long so I left this change behind: attributes in the external-link tag weren't being escaped before being inserted into the tree.