### PR TITLE
markdown: fix issue with italicised links containing underscores in t…

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -40,6 +40,7 @@ const plugins = [
   },
   {
     options: {
+      pedantic: false,
       plugins: [
         {
           resolve: 'gatsby-remark-embedder'


### PR DESCRIPTION
…he address

In [this conversation](https://github.com/remarkjs/remark/issues/470) it was suggested that we disable pedantic mode, since it's an emulation of a buggy old version of markdown.

I checked using my diff tool, which articles changed after disabling pedantic mode, and besides fixing the original issue, errors in the following pages were corrected.

 - https://blog.dvc.org/september-19-dvc-heartbeat (search for `**`)
 - https://blog.dvc.org/https://blog.dvc.org/r-code-and-reproducible-model-development-with-dvc (search for `traintestspliting.py` - it should be `train_test_spliting.py`)
 - https://blog.dvc.org/best-practices-of-orchestrating-python-and-r-code-in-ml-projects (search for `trainmodelpython.py` - it should have underscores)

Closes #119 