### PR TITLE
server: use cache headers

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -19,6 +19,17 @@ const app = express();
 const serveOptions = {
   directoryListing: false,
   etag: true,
+  headers: [
+    {
+      headers: [
+        {
+          key: 'Cache-Control',
+          value: 'public, max-age=3600'
+        }
+      ],
+      source: '*'
+    }
+  ],
   public: path.join(__dirname, '../../public'),
   trailingSlash: false
 };


### PR DESCRIPTION
This sets cache headers so cloudflare can cache the HTML and assets of the site.