### PR TITLE
deployment: force browser cache revalidation and purge cache after deploys

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,6 +12,8 @@
     }
   },
   "name": "dvc-blog-production",
-  "scripts": {},
+  "scripts": {
+    "postdeploy": "./scripts/heroku-postdeploy.sh"
+  },
   "stack": "heroku-18"
 }

--- a/scripts/heroku-postdeploy.sh
+++ b/scripts/heroku-postdeploy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This script runs after each heroku deploy. If the deploy is the
+# production heroku app (the only one with the below variables)
+# the cache gets cleared.
+#
+# To clear the cache yourself, you can use the button in the
+# cloudflare dashboard ("Caching tab > Purge everything"), or run
+# this script with the required environment variables:
+#
+# - CLOUDFLARE_TOKEN: a token with the "Zone.Cache Purge" permission.
+# You can generate this token in "My Profile > API Tokens"
+#
+# - CLOUDFLARE_ZONE_ID: The zone ID to purge. You can find it in the
+# sidebar of the "overview" tab for dvc.org
+
+set -euo pipefail
+
+if [ -z "${CLOUDFLARE_TOKEN:-}" ]; then
+  exit 0
+fi
+
+curl --fail \
+  --request POST \
+  --url "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+  --header "authorization: Bearer ${CLOUDFLARE_TOKEN}" \
+  --header "content-type: application/json" \
+  --data '{ "purge_everything": true }'
+
+# The response to the above is not newline-terminated, add some newlines for spacing.
+echo "
+
+postdeploy script: Cloudflare cache purged successfully!"

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -22,9 +22,11 @@ const staticFilesOptions = {
   headers: [
     {
       headers: [
+        // Cache always revalidated by the client, not by the proxy
+        // (instant deploys when combined with the post-deploy purge)
         {
           key: 'Cache-Control',
-          value: 'public, max-age=900'
+          value: 'public, max-age=0, s-maxage=99999'
         }
       ],
       source: '**'


### PR DESCRIPTION
This enables an instant deploy, where the browser always has the latest version of everything. The trade-off is that it has to always revalidate. It's possible to not have mandatory revalidation on the content-addressible parts (JS/CSS compiled chunks, generated thumbnails), but that's a story for another time I guess.

I've already:

 - Checked that both chrome and firefox are spec-compliant and always revalidate when given these headers
 - Checked that the CLOUDFLARE_TOKEN and CLOUDFLARE_ZONE_ID are secret when set at the heroku app level
 - Added the above variables to the production app, to make this script work (this token only has the capability of purging cache, so if it's leaked not much damage can be done)
 - Checked that the script works by running it myself