### PR TITLE
update node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12.0.0"
+    "node": "^12.0.0"
   },
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
Heroku is complaining about the broad `>=12.0.0` version range, so I changed it to `^` (major == 12)