### PR TITLE
deployment: deploy statics to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp/*
 .DS_Store
 .idea
 .vscode
+404.html

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "gatsby build",
+    "heroku-postbuild": "./scripts/deploy-with-s3.js",
     "develop": "gatsby develop",
     "start": "./scripts/clear-cloudflare-cache.js; node ./src/server/server.js",
     "typecheck": "tsc --noEmit --skipLibCheck",
@@ -39,6 +40,7 @@
     ]
   },
   "dependencies": {
+    "@hapi/wreck": "^17.0.0",
     "@reach/portal": "^0.5.0",
     "@reach/tooltip": "^0.5.4",
     "@types/google.analytics": "^0.0.40",
@@ -52,6 +54,7 @@
     "gatsby-remark-embedder": "^1.8.0",
     "gatsby-remark-relative-images": "^0.2.3",
     "hast-util-select": "^3.0.1",
+    "mime-types": "^2.1.26",
     "node-fetch": "^2.6.0",
     "prismjs": "^1.17.1",
     "react": "^16.11.0",
@@ -71,6 +74,7 @@
     "@types/react-dom": "^16.9.4",
     "@types/react-helmet": "^5.0.14",
     "autoprefixer": "^9.7.1",
+    "fs-extra": "^8.1.0",
     "gatsby-plugin-feed": "^2.3.26",
     "gatsby-plugin-google-analytics": "^2.1.33",
     "gatsby-plugin-manifest": "^2.2.37",
@@ -99,6 +103,7 @@
     "postcss-nested": "^4.2.1",
     "prettier": "^1.19.1",
     "remark-html": "^10.0.0",
+    "s3-client": "^4.4.2",
     "stylelint": "^11.1.1",
     "stylelint-config-standard": "^19.0.0",
     "tslint": "^5.20.1",
@@ -110,7 +115,6 @@
   },
   "cacheDirectories": [
     "node_modules",
-    ".cache",
-    "public"
+    ".cache"
   ]
 }

--- a/scripts/deploy-with-s3.js
+++ b/scripts/deploy-with-s3.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Build gatsby site and deploy public/ to s3.
+ *
+ * The S3 path of the deployment depends on the HEROKU_APP_NAME variable,
+ * which is passed to PRs by heroku, but you can set locally too.
+ *
+ * With HEROKU_APP_NAME: /dvc-org-pulls/$HEROKU_APP_NAME
+ * Without HEROKU_APP_NAME: /dvc-org-prod
+ *
+ * Needs following environment variables:
+ *
+ *  - S3_BUCKET: name of the bucket
+ *  - AWS_REGION: region of the bucket
+ *  - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY: auth token to access the bucket.
+ *  - HEROKU_APP_NAME: (optional) app name to specify the ID of the PR if any.
+ **/
+
+const path = require('path');
+const { execSync } = require('child_process');
+const { remove, move } = require('fs-extra');
+const { s3Prefix, s3Bucket, s3Client } = require('./s3-utils');
+
+const rootDir = path.join(__dirname, '..');
+const cacheDir = path.join(rootDir, '.cache');
+const publicDir = path.join(rootDir, 'public');
+
+function run(command) {
+  execSync(command, {
+    stdio: ['pipe', process.stdout, process.stderr]
+  });
+}
+
+function syncCall(method, ...args) {
+  return new Promise((resolve, reject) => {
+    const synchroniser = s3Client[method](...args);
+    synchroniser.on('error', reject);
+    synchroniser.on('end', resolve);
+  });
+}
+
+async function prefixIsEmpty(prefix) {
+  try {
+    await s3Client.s3
+      .headObject({
+        Bucket: s3Bucket,
+        Prefix: prefix + '/index.html'
+      })
+      .promise();
+    return false;
+  } catch (e) {
+    return true;
+  }
+}
+
+async function downloadFromS3(prefix) {
+  try {
+    console.log(`downloading public/ from s3://${s3Bucket}/${prefix}`);
+    console.time('download from s3');
+    await syncCall('downloadDir', {
+      localDir: publicDir,
+      s3Params: {
+        Bucket: s3Bucket,
+        Prefix: prefix
+      }
+    });
+    console.timeEnd('download from s3');
+  } catch (downloadError) {
+    console.error('Error downloading initial data', downloadError);
+    // Don't propagate. It's just a cache warming step
+  }
+}
+
+async function uploadToS3() {
+  console.log(`Uploading public/ to s3://${s3Bucket}/${s3Prefix}`);
+  console.time('upload to s3');
+  await syncCall('uploadDir', {
+    localDir: publicDir,
+    deleteRemoved: true,
+    s3Params: {
+      Bucket: s3Bucket,
+      Prefix: s3Prefix
+    }
+  });
+  console.timeEnd('upload to s3');
+}
+
+async function main() {
+  const emptyPrefix = await prefixIsEmpty(s3Prefix);
+
+  // First build of a PR is slow because it can't reuse cache.
+  // But we can download from prod to warm cache up.
+  const cacheWarmPrefix = emptyPrefix ? 'dvc-org-prod' : s3Prefix;
+
+  await downloadFromS3(cacheWarmPrefix);
+
+  try {
+    run('yarn build');
+  } catch (buildError) {
+    // Sometimes gatsby build fails because of bad cache.
+    // Clear it and try again.
+
+    console.error('------------------------\n\n');
+    console.error(buildError);
+    console.error('\nAssuming bad cache and retrying:\n');
+
+    await remove(cacheDir);
+    await remove(publicDir);
+    run('yarn build');
+  }
+
+  await move(path.join(publicDir, '404.html'), path.join(rootDir, '404.html'), {
+    overwrite: true
+  });
+  await uploadToS3();
+  await remove(publicDir);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/s3-utils.js
+++ b/scripts/s3-utils.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { s3Prefix, s3Bucket } = require('../src/server/s3');
+const s3 = require('s3-client');
+
+const {
+  AWS_REGION,
+  AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY,
+  HEROKU_APP_NAME
+} = process.env;
+
+const s3Client = s3.createClient({
+  maxAsyncS3: 50,
+  region: AWS_REGION,
+  accessKeyId: AWS_ACCESS_KEY_ID,
+  secretAccessKey: AWS_SECRET_ACCESS_KEY
+});
+
+console.log({
+  AWS_REGION,
+  HEROKU_APP_NAME,
+  s3Bucket,
+  s3Prefix,
+  hasCreds: Boolean(AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY)
+});
+
+module.exports = {
+  s3Bucket,
+  s3Prefix,
+  s3Client
+};

--- a/src/server/s3.js
+++ b/src/server/s3.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { AWS_REGION, S3_BUCKET, HEROKU_APP_NAME } = process.env;
+
+const s3Prefix = HEROKU_APP_NAME
+  ? `dvc-org-pulls/${HEROKU_APP_NAME}`
+  : 'dvc-org-prod';
+const s3Bucket = S3_BUCKET;
+const s3Url = `http://${s3Bucket}.s3-website.${AWS_REGION}.amazonaws.com/${s3Prefix}`;
+
+module.exports = { s3Prefix, s3Bucket, s3Url };

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,45 +1,96 @@
 /* eslint-env node */
 
+'use strict';
+
 /*
- * Production server.
+ * Production server. Proxies to S3 depending on HEROKU_APP_NAME (see
+ * scripts/deploy-with-s3.js)
  *
  * NOTE: This file doesn't go through babel or webpack. Make sure the syntax and
  * sources this file requires are compatible with the current node version you
  * are running.
+ *
+ * Required environment variables:
+ *
+ *  - S3_BUCKET: name of the bucket
+ *  - AWS_REGION: region of the bucket
+ *  - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY: IAM token to access bucket
+ *  - HEROKU_APP_NAME: If this is a PR, an ID of the PR. Don't add this for
+ *    production.
  */
 
+const fs = require('fs');
+const crypto = require('crypto');
+const url = require('url');
 const path = require('path');
+const fetch = require('node-fetch');
 const express = require('express');
-const serve = require('serve-handler');
+const mime = require('mime-types');
+const Wreck = require('@hapi/wreck');
+const { s3Url } = require('./s3');
 
-const port = process.env.PORT || 9000;
 const app = express();
 
-const staticFilesOptions = {
-  directoryListing: false,
-  etag: true,
-  headers: [
-    {
-      headers: [
-        // Cache always revalidated by the client, not by the proxy
-        // (instant deploys when combined with the post-deploy purge)
-        {
-          key: 'Cache-Control',
-          value: 'public, max-age=0, s-maxage=99999'
-        }
-      ],
-      source: '**'
-    }
-  ],
-  public: path.join(__dirname, '../../public'),
-  trailingSlash: false
-};
+const { PORT = 9000, NODE_ENV } = process.env;
 
-app.use((req, res) => {
-  serve(req, res, staticFilesOptions);
+const cacheControl = 'public, max-age=0, s-maxage=999999';
+const htmlType = 'text/html; charset=utf-8';
+
+let notFoundPage;
+try {
+  // in production there's no public folder
+  notFoundPage = fs.readFileSync(path.join(__dirname, '../../404.html'));
+} catch (e) {
+  notFoundPage = fs.readFileSync(path.join(__dirname, '../../public/404.html'));
+}
+
+async function serveFile(pathname, res) {
+  const target = s3Url + pathname;
+
+  const proxyRes = await Wreck.request('GET', target, {
+    redirects: 2,
+    timeout: 5000
+  });
+
+  const { statusCode, headers: { etag } = {} } = proxyRes;
+
+  if (statusCode !== 200) {
+    throw new Error('Response not successful: ' + statusCode);
+  }
+
+  res.writeHead(200, {
+    'cache-control': cacheControl,
+    'content-type': mime.lookup(pathname) || htmlType,
+    etag
+  });
+
+  proxyRes.pipe(res);
+}
+
+app.use(async (req, res) => {
+  const { pathname } = url.parse(req.url);
+
+  if (pathname.endsWith('/') && pathname !== '/') {
+    res.writeHead(301, { location: pathname.slice(0, -1) }).end();
+
+    return;
+  }
+
+  try {
+    await serveFile(pathname, res);
+  } catch (e) {
+    res
+      .writeHead(404, {
+        'cache-control': cacheControl,
+        'content-type': htmlType
+      })
+      .end(notFoundPage);
+  }
 });
 
-app.listen(port, e => {
-  /* tslint:disable-next-line:no-console */
-  console.log(`Listening on http://0.0.0.0:${port}/`);
+app.listen(PORT, e => {
+  /* tslint:disable:no-console */
+  console.log(`Listening on http://0.0.0.0:${PORT}/`);
+  console.log(`Proxying to ${s3Url}`);
+  /* tslint:enable:no-console */
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,15 +951,32 @@
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
   integrity sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==
 
+"@hapi/boom@9.x.x":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/boom/-/boom-9.0.0.tgz#28f9e77ecf2dea1fe3a8982b9d8827aa5137e33a"
+  integrity sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==
+  dependencies:
+    "@hapi/hoek" "9.x.x"
+
 "@hapi/bourne@1.x.x":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-1.3.2.tgz#0a7095adea067243ce3283e1b56b8a8f453b242a"
   integrity sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==
 
+"@hapi/bourne@2.x.x":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-2.0.0.tgz#5bb2193eb685c0007540ca61d166d4e1edaf918d"
+  integrity sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==
+
 "@hapi/hoek@8.x.x", "@hapi/hoek@^8.3.0":
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.0.tgz#2f9ce301c8898e1c3248b0a8564696b24d1a9a5a"
   integrity sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==
+
+"@hapi/hoek@9.x.x":
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.0.3.tgz#e49e637d5de8faa4f0d313c2590b455d7c00afd7"
+  integrity sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg==
 
 "@hapi/joi@^15.1.1":
   version "15.1.1"
@@ -977,6 +994,15 @@
   integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
     "@hapi/hoek" "^8.3.0"
+
+"@hapi/wreck@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/wreck/-/wreck-17.0.0.tgz#8ab0ca286e937c3f7a82f67e4be4348c824b743c"
+  integrity sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==
+  dependencies:
+    "@hapi/boom" "9.x.x"
+    "@hapi/bourne" "2.x.x"
+    "@hapi/hoek" "9.x.x"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
@@ -2545,6 +2571,21 @@ autoprefixer@^9.5.1, autoprefixer@^9.7.1, autoprefixer@^9.7.3:
     postcss "^7.0.26"
     postcss-value-parser "^4.0.2"
 
+aws-sdk@^2.328.0:
+  version "2.633.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.633.0.tgz#3bdb8ec2671884025e9f64fdfa2c0af3cc663118"
+  integrity sha512-C28/GefIQ+Dk1hjPQrpG1Yt9RdvqeFMP4nb6iActanoGq5JTSJU9103ukpBzrHz96fvjhIRogrvfOhDKubbcjw==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -3152,6 +3193,15 @@ buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 buffer@^4.3.0:
   version "4.9.2"
@@ -5479,6 +5529,11 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
   integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 events@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
@@ -5876,7 +5931,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fd-slicer@~1.1.0:
+fd-slicer@^1.1.0, fd-slicer@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
@@ -6073,6 +6128,11 @@ find-versions@^3.0.0:
   integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
   dependencies:
     semver-regex "^2.0.0"
+
+findit2@~2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/findit2/-/findit2-2.2.3.tgz#58a466697df8a6205cdfdbf395536b8bd777a5f6"
+  integrity sha1-WKRmaX34piBc39vzlVNri9d3pfY=
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -7141,6 +7201,11 @@ graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
+graceful-fs@~4.1.11:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
@@ -7765,7 +7830,7 @@ icss-utils@^2.1.0:
   dependencies:
     postcss "^6.0.1"
 
-ieee754@^1.1.4:
+ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -9075,6 +9140,11 @@ jimp@^0.6.4:
     core-js "^2.5.7"
     regenerator-runtime "^0.13.3"
 
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+
 jpeg-js@^0.3.4:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.6.tgz#c40382aac9506e7d1f2d856eb02f6c7b2a98b37c"
@@ -10095,7 +10165,7 @@ mime-types@2.1.18:
   dependencies:
     mime-db "~1.33.0"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@^2.1.26, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.26"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
   integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
@@ -10107,7 +10177,7 @@ mime@1.6.0, mime@^1.3.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3, mime@^2.4.4:
+mime@^2.0.3, mime@^2.3.1, mime@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
@@ -13096,7 +13166,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2.6.3:
+rimraf@2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -13196,6 +13266,21 @@ rxjs@^6.3.3, rxjs@^6.5.3:
   dependencies:
     tslib "^1.9.0"
 
+s3-client@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/s3-client/-/s3-client-4.4.2.tgz#bb41f25abe1342a4f61189063f473e407208da47"
+  integrity sha512-XVL6vR9W6Rg3/pyWxKt2Gt+EiLEceKUFvjv69GmED6K8zta0/+kCYIpWtgOXtfYGHzZ8Cr55D2SLAEYHay3kTw==
+  dependencies:
+    aws-sdk "^2.328.0"
+    fd-slicer "^1.1.0"
+    findit2 "~2.2.3"
+    graceful-fs "~4.1.11"
+    mime "^2.3.1"
+    mkdirp "~0.5.1"
+    pend "~1.2.0"
+    rimraf "~2.6.2"
+    streamsink "~1.2.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -13248,6 +13333,11 @@ sanitize-html@^1.20.1:
     postcss "^7.0.5"
     srcset "^1.0.0"
     xtend "^4.0.1"
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
 
 sax@>=0.6.0, sax@~1.2.4:
   version "1.2.4"
@@ -14057,6 +14147,11 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+streamsink@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/streamsink/-/streamsink-1.2.0.tgz#efafee9f1e22d3591ed7de3dcaa95c3f5e79f73c"
+  integrity sha1-76/unx4i01ke1949yqlcP1559zw=
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -15337,6 +15432,14 @@ url-to-options@^1.0.1:
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
   integrity sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -15395,6 +15498,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@3.3.3:
   version "3.3.3"
@@ -15907,6 +16015,14 @@ xml-parse-from-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz#a9029e929d3dbcded169f3c6e28238d95a5d5a28"
   integrity sha1-qQKekp09vN7RafPG4oI42VpdWig=
 
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
 xml2js@^0.4.5:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
@@ -15924,6 +16040,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlchars@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
So here's what I've been working on this week.

It's not ready to merge, because the script that destroys the PR isn't working for some reason. I can't debug it since there are no logs in the destroy script, so on monday, I'll set up an ngrok and POST stuff to my laptop so I can read errors.

## Strategy

I've replaced the build command only on heroku, such that it:

1. Downloads the public/ folder from S3 (if it's a cold PR it gets the production folder since there are no secrets there)
2. Runs gatsby build
3. Uploads the public/ folder to S3.

The production server then merely proxies to S3. It doesn't work for your local public/ folder.

## Timings

Production build: 3min
First PR build: 4min
Subsequent builds of the same PR: 3min

Downloading and uploading from S3 takes very little time. I was able to increase the request concurrency to 50, so the initial download only takes 10 seconds. Uploading to an already-hot S3 bucket takes around 3 seconds since most files will already be there.

## Drawbacks

In AWS, I've created two IAM users, one for production (which has write access to the production prefix of my bucket), and another for PRs (which has access to $bucket/pulls/*). This means that if someone can leak the tokens in their build (by changing the build command) they can mess with other people's PRs. Therefore, we shouldn't enable automatic PR builds.